### PR TITLE
fix: preserve ticket closer in transcript generation

### DIFF
--- a/src/main/kotlin/net/dungeonhub/application/listener/ticket/TicketCloseListener.kt
+++ b/src/main/kotlin/net/dungeonhub/application/listener/ticket/TicketCloseListener.kt
@@ -190,7 +190,7 @@ class TicketCloseListener : Extension() {
 
                 TicketTranscriptListener.generateTranscript(
                     textChannel,
-                    null,
+                    member,
                     updatedTicket,
                     updatedTicket.ticketPanel.closeTranscriptTarget
                 )

--- a/src/main/kotlin/net/dungeonhub/application/misc/TicketPlaceholders.kt
+++ b/src/main/kotlin/net/dungeonhub/application/misc/TicketPlaceholders.kt
@@ -88,6 +88,9 @@ class TicketPlaceholders(
             }
             replacements["user.name"] = { ticketUser.await()?.username ?: "unknown" }
             replacements["user.displayName"] = { ticketUser.await()?.effectiveName ?: "unknown" }
+            replacements["interactionUser.id"] = { interactionUser.id.value.toString() }
+            replacements["interactionUser.mention"] = { interactionUser.mention }
+            replacements["interactionUser.name"] = { interactionUser.username }
             replacements["interactionUser.displayName"] = { interactionUser.effectiveName }
             replacements["user.minecraft.name"] = { ticketUserIgn.await() ?: "unlinked" }
             replacements["user.skyblock.level"] = {


### PR DESCRIPTION
## Summary
This fixes ticket transcripts showing the bot/self account as the closer instead of the user who actually clicked the close button.

## Cause
When a ticket was closed through `TicketCloseListener`, the transcript generation call passed `null` as the requester, so the transcript flow lost the actual closing user context.

## Fix
- pass the closing member into `TicketTranscriptListener.generateTranscript(...)`
- add `interactionUser.id`, `interactionUser.mention`, and `interactionUser.name` placeholders for transcript/template usage
