### PR TITLE
Improved the birthday service to only send if the user actually has access to the channel.

### DIFF
--- a/src/main/kotlin/net/dungeonhub/application/service/BirthdayService.kt
+++ b/src/main/kotlin/net/dungeonhub/application/service/BirthdayService.kt
@@ -101,9 +101,9 @@ object BirthdayService : StartupListener {
         for (birthday in todayBirthdays) {
             val birthdayUser = DiscordConnection.bot.kordRef.getUser(Snowflake(birthday.userId))?.asMemberOrNull(birthdayChannel.guildId)
 
-            if(birthdayUser == null || birthdayChannel.permissionsForMember(birthdayUser).contains(Permission.ViewChannel)) {
+            if (birthdayUser == null || !birthdayChannel.permissionsForMember(birthdayUser).contains(Permission.ViewChannel)) {
                 logger.error("Birthday user doesn't have access to the birthday channel. Skipping ${birthday.userId}/${birthdayUser?.effectiveName} with permissions ${birthdayUser?.let { birthdayChannel.permissionsForMember(it) }}.")
-                return
+                continue
             }
 
             val embed = EmbedBuilder()

--- a/src/main/kotlin/net/dungeonhub/application/service/BirthdayService.kt
+++ b/src/main/kotlin/net/dungeonhub/application/service/BirthdayService.kt
@@ -1,9 +1,11 @@
 package net.dungeonhub.application.service
 
+import dev.kord.common.entity.Permission
 import dev.kord.common.entity.Snowflake
 import dev.kord.core.behavior.channel.createMessage
 import dev.kord.core.entity.channel.GuildMessageChannel
 import dev.kord.rest.builder.message.EmbedBuilder
+import dev.kordex.core.utils.permissionsForMember
 import dev.kordex.core.utils.scheduling.Scheduler
 import io.ktor.client.request.*
 import io.ktor.client.statement.*
@@ -31,10 +33,8 @@ import kotlin.time.Duration
 import kotlin.time.Duration.Companion.hours
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
-import kotlin.time.ExperimentalTime
 
 @OnStart
-@OptIn(ExperimentalTime::class)
 object BirthdayService : StartupListener {
     private const val BIRTHDAY_CALENDAR_URL =
         "https://cloud.dungeon-hub.net/remote.php/dav/public-calendars/g2tZRB2YpacJtAtt?export"
@@ -91,7 +91,21 @@ object BirthdayService : StartupListener {
         val todayBirthdays = getTodayBirthdays(Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault()))
         val embeds: MutableList<EmbedBuilder> = mutableListOf()
 
+        val birthdayChannel = DiscordConnection.bot.kordRef.getChannelOf<GuildMessageChannel>(Snowflake(BIRTHDAYS_CHANNEL))
+
+        if(birthdayChannel == null) {
+            logger.error("Couldn't find the birthday channel.")
+            return
+        }
+
         for (birthday in todayBirthdays) {
+            val birthdayUser = DiscordConnection.bot.kordRef.getUser(Snowflake(birthday.userId))?.asMemberOrNull(birthdayChannel.guildId)
+
+            if(birthdayUser == null || birthdayChannel.permissionsForMember(birthdayUser).contains(Permission.ViewChannel)) {
+                logger.error("Birthday user doesn't have access to the birthday channel. Skipping ${birthday.userId}/${birthdayUser?.effectiveName} with permissions ${birthdayUser?.let { birthdayChannel.permissionsForMember(it) }}.")
+                return
+            }
+
             val embed = EmbedBuilder()
             embed.color(EmbedColor.Positive)
             embed.title = birthday.eventName
@@ -111,11 +125,10 @@ object BirthdayService : StartupListener {
         }
 
         if (embeds.isNotEmpty()) {
-            DiscordConnection.bot.kordRef.getChannelOf<GuildMessageChannel>(Snowflake(BIRTHDAYS_CHANNEL))
-                ?.createMessage {
-                    this.content = "<@&$BIRTHDAY_PING_ROLE>"
-                    this.embeds = embeds
-                }
+            birthdayChannel.createMessage {
+                this.content = "<@&$BIRTHDAY_PING_ROLE>"
+                this.embeds = embeds
+            }
         }
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Birthday notifications now verify the configured channel exists before attempting to send.
  * Birthday content is generated and shared only for members with the required channel viewing permission.
  * Birthday announcements are posted as a single consolidated message (with the accumulated embeds), improving consistency and reducing partial/failed delivery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->