### PR TITLE
Removed the loading of the carry tier through the category in the autocompletion event, since that isn't used further in commands.

### DIFF
--- a/src/main/kotlin/net/dungeonhub/application/service/AutoCompletionService.kt
+++ b/src/main/kotlin/net/dungeonhub/application/service/AutoCompletionService.kt
@@ -2,9 +2,7 @@ package net.dungeonhub.application.service
 
 import dev.kord.common.entity.Choice
 import dev.kord.common.entity.optional.Optional
-import dev.kord.core.behavior.channel.asChannelOfOrNull
 import dev.kord.core.behavior.interaction.suggest
-import dev.kord.core.entity.channel.CategorizableChannel
 import dev.kord.core.event.interaction.AutoCompleteInteractionCreateEvent
 import dev.kordex.core.commands.converters.AutoCompleteCallback
 import net.dungeonhub.application.enums.KnownStaticResource
@@ -107,19 +105,11 @@ object AutoCompletionService {
 
             val ticket = DiscordServerConnection.authenticated().findTickets(guildId, channelId = channel.id.value.toLong())?.firstOrNull()
 
-            val carryTierByCategory = ticket?.let { getCarryTierFromTicket(it) }
-                ?: channel.asChannelOfOrNull<CategorizableChannel>()
-                    ?.categoryId
-                    ?.let { categoryId ->
-                        DiscordServerConnection.authenticated().getCarryTierFromCategory(
-                            guildId,
-                            categoryId.value.toLong()
-                        )
-                    }
+            val ticketCarryTier = ticket?.let { getCarryTierFromTicket(it) }
 
-            if (carryTierByCategory != null) {
+            if (ticketCarryTier != null) {
                 suggest(
-                    CarryDifficultyConnection[carryTierByCategory].authenticated()
+                    CarryDifficultyConnection[ticketCarryTier].authenticated()
                         .getAllCarryDifficulties()
                         ?.filter { carryDifficulty ->
                             focusedOption.value.isEmpty()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Carry-difficulty autocomplete suggestions now use the ticket’s carry tier exclusively.
  * Suggestions are no longer generated from the channel category when ticket information is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->