### PR TITLE
Introduce EmbedJsonService and centralize embed JSON parsing

### DIFF
--- a/src/main/kotlin/net/dungeonhub/application/commands/CntSystem.kt
+++ b/src/main/kotlin/net/dungeonhub/application/commands/CntSystem.kt
@@ -32,7 +32,7 @@ import dev.kordex.core.pagination.pages.Page
 import dev.kordex.core.utils.dm
 import dev.kordex.core.utils.hasPermission
 import kotlinx.coroutines.launch
-import net.dungeonhub.application.connection.copy
+import net.dungeonhub.application.service.copy
 import net.dungeonhub.application.enums.EmbedColor
 import net.dungeonhub.application.enums.HelpTopic
 import net.dungeonhub.application.enums.ServerProperty

--- a/src/main/kotlin/net/dungeonhub/application/commands/EmbedCommand.kt
+++ b/src/main/kotlin/net/dungeonhub/application/commands/EmbedCommand.kt
@@ -1,9 +1,7 @@
 package net.dungeonhub.application.commands
 
-import com.google.gson.JsonElement
-import com.google.gson.JsonObject
-import com.google.gson.JsonSyntaxException
-import com.squareup.moshi.adapter
+import com.squareup.moshi.JsonDataException
+import dev.kord.rest.builder.message.EmbedBuilder
 import dev.kord.common.entity.ChannelType
 import dev.kord.common.entity.Permission
 import dev.kord.common.entity.Permissions
@@ -12,7 +10,6 @@ import dev.kord.core.behavior.channel.createMessage
 import dev.kord.core.behavior.edit
 import dev.kord.core.entity.Message
 import dev.kord.core.entity.channel.MessageChannel
-import dev.kord.rest.builder.message.EmbedBuilder
 import dev.kordex.core.commands.Arguments
 import dev.kordex.core.commands.application.slash.converters.impl.optionalStringChoice
 import dev.kordex.core.commands.application.slash.publicSubCommand
@@ -24,7 +21,6 @@ import dev.kordex.core.extensions.publicSlashCommand
 import dev.kordex.core.i18n.toKey
 import dev.kordex.core.utils.getJumpUrl
 import net.dungeonhub.application.config.ConfigProperty
-import net.dungeonhub.application.connection.applyJson
 import net.dungeonhub.application.connection.loadMessageByLink
 import net.dungeonhub.application.connection.toBuilder
 import net.dungeonhub.application.connection.toModel
@@ -35,12 +31,11 @@ import net.dungeonhub.application.exceptions.InvalidOptionException
 import net.dungeonhub.application.loader.LoadExtension
 import net.dungeonhub.application.misc.EmbedModel
 import net.dungeonhub.application.service.ApplicationService
+import net.dungeonhub.application.service.EmbedJsonService
 import net.dungeonhub.connection.ContentConnection
 import net.dungeonhub.i18n.Translations.Command.Embed
-import net.dungeonhub.service.GsonService
-import net.dungeonhub.service.MoshiService
+import java.io.IOException
 import java.nio.charset.StandardCharsets
-import java.util.function.Consumer
 
 /**
  * This extension provides the ability to manage embeds.
@@ -95,28 +90,17 @@ class EmbedCommand : Extension() {
                         embedBuilder.color = EmbedColor.Default.color
 
                         if (beautiful && embeds.size == 1) {
-                            @Suppress("DEPRECATION")
-                            GsonService.gson.toJsonTree(embeds[0].toModel())
-                                .asJsonObject
-                                .entrySet()
-                                .forEach(Consumer { entry: Map.Entry<String, JsonElement> ->
-                                    embedBuilder.field(
-                                        entry.key,
-                                        false
-                                    )
-                                    {
-                                        if(entry.value.isJsonPrimitive) {
-                                            entry.value.asString
-                                        } else {
-                                            entry.value.toString()
-                                        }
+                            EmbedJsonService.toJsonMap(embeds[0].toModel())
+                                .forEach { (key, value) ->
+                                    embedBuilder.field(key, false) {
+                                        value as? String ?: EmbedJsonService.toJsonValue(value)
                                     }
-                                })
+                                }
                         } else {
                             val embedSource = if (embeds.size == 1) {
-                                MoshiService.moshi.adapter<EmbedModel>().toJson(embeds[0].toModel())
+                                EmbedJsonService.toJson(embeds[0].toModel())
                             } else {
-                                MoshiService.moshi.adapter<List<EmbedModel>>().toJson(embeds.map { it.toModel() })
+                                EmbedJsonService.toJson(embeds.map { it.toModel() })
                             }
 
                             val description =
@@ -157,60 +141,14 @@ class EmbedCommand : Extension() {
                                 ?: throw CommandExecutionException("Couldn't download the file correctly.")
                         }
 
-                        //TODO write tests for this; maybe also add an improved command that uses discord fields
-                        val embedBuilders: MutableList<EmbedBuilder> = ArrayList()
-
-                        try {
-                            @Suppress("DEPRECATION")
-                            val embedSource = GsonService.gson.fromJson(
-                                source,
-                                JsonElement::class.java
-                            )
-
-                            if (embedSource.isJsonObject) {
-                                val embedBuilder = EmbedBuilder()
-
-                                embedSource.asJsonObject
-                                    .entrySet()
-                                    .forEach { entry: Map.Entry<String, JsonElement> ->
-                                        embedBuilder.applyJson(
-                                            entry.key,
-                                            entry.value
-                                        )
-                                    }
-
-                                embedBuilders.add(embedBuilder)
-                            } else if (embedSource.isJsonArray) {
-                                embedSource.asJsonArray
-                                    .forEach { jsonElement: JsonElement ->
-                                        if (jsonElement.isJsonObject) {
-                                            val embedBuilder = EmbedBuilder()
-
-                                            jsonElement.asJsonObject
-                                                .entrySet()
-                                                .forEach { entry: Map.Entry<String, JsonElement> ->
-                                                    embedBuilder.applyJson(
-                                                        entry.key,
-                                                        entry.value
-                                                    )
-                                                }
-
-                                            embedBuilders.add(embedBuilder)
-                                        }
-                                    }
-                            }
-                        } catch (_: JsonSyntaxException) {
-                            throw InvalidEmbedJsonWarning()
-                        } catch (exception: Exception) {
-                            throw CommandExecutionException(exception)
-                        }
+                        val embedBuilders = parseEmbedInput(source)
 
                         if (embedBuilders.isEmpty()) {
                             throw CommandExecutionException("Please provide any embeds to send.")
                         }
 
                         channel.createMessage {
-                            embeds = embedBuilders
+                            embeds = embedBuilders.toMutableList()
                         }
 
                         val embed = ApplicationService.embed
@@ -227,52 +165,7 @@ class EmbedCommand : Extension() {
 
                 action {
                     respond {
-                        val embedBuilders: MutableList<EmbedBuilder> = mutableListOf()
-
-                        try {
-                            @Suppress("DEPRECATION")
-                            val embedSource = GsonService.gson.fromJson(
-                                arguments.embed,
-                                JsonElement::class.java
-                            )
-
-                            if (embedSource.isJsonObject) {
-                                val embedBuilder = EmbedBuilder()
-
-                                embedSource.asJsonObject
-                                    .entrySet()
-                                    .forEach {
-                                        embedBuilder.applyJson(
-                                            it.key,
-                                            it.value
-                                        )
-                                    }
-
-                                embedBuilders.add(embedBuilder)
-                            } else if (embedSource.isJsonArray) {
-                                embedSource.asJsonArray
-                                    .forEach { jsonElement: JsonElement ->
-                                        if (jsonElement.isJsonObject) {
-                                            val embedBuilder = EmbedBuilder()
-
-                                            jsonElement.asJsonObject
-                                                .entrySet()
-                                                .forEach { entry: Map.Entry<String, JsonElement> ->
-                                                    embedBuilder.applyJson(
-                                                        entry.key,
-                                                        entry.value
-                                                    )
-                                                }
-
-                                            embedBuilders.add(embedBuilder)
-                                        }
-                                    }
-                            }
-                        } catch (_: JsonSyntaxException) {
-                            throw InvalidEmbedJsonWarning()
-                        } catch (exception: java.lang.Exception) {
-                            throw CommandExecutionException(exception)
-                        }
+                        val embedBuilders = parseEmbedInput(arguments.embed)
 
                         if (embedBuilders.isEmpty()) {
                             throw CommandExecutionException("Please provide any embeds to send.")
@@ -314,27 +207,14 @@ class EmbedCommand : Extension() {
 
                 action {
                     respond {
-                        val embed = EmbedBuilder()
-                        try {
-                            @Suppress("DEPRECATION")
-                            val embedSource: JsonObject = GsonService.gson.fromJson(
-                                arguments.embed,
-                                JsonObject::class.java
-                            )
+                        val parsedEmbeds = parseEmbedInput(arguments.embed)
 
-                            embedSource.entrySet().forEach { entry: Map.Entry<String, JsonElement> ->
-                                embed.applyJson(
-                                    entry.key,
-                                    entry.value
-                                )
-                            }
-                        } catch (_: JsonSyntaxException) {
-                            throw InvalidEmbedJsonWarning()
-                        } catch (exception: Exception) {
-                            throw CommandExecutionException(exception)
+                        if (parsedEmbeds.isEmpty()) {
+                            throw CommandExecutionException("Please provide any embeds to edit.")
                         }
 
-                        val count = arguments.count ?: 0
+                        val count = arguments.count
+                        val replacesWholeMessage = count == null && arguments.embed.trimStart().startsWith("[")
 
                         val message = arguments.getMessage()
 
@@ -356,27 +236,75 @@ class EmbedCommand : Extension() {
                         }
 
                         message.edit {
-                            val embedBuilders = message.embeds.map { it.toBuilder() }.toMutableList()
-                            if (count >= embedBuilders.size) {
-                                throw InvalidOptionException(
-                                    "link",
-                                    "The given message doesn't have that many embeds."
-                                )
-                            }
+                            embeds = if (replacesWholeMessage) {
+                                parsedEmbeds.toMutableList()
+                            } else {
+                                val embedBuilders = message.embeds.map { it.toBuilder() }.toMutableList()
+                                val editIndex = count ?: 0
+                                if (editIndex >= embedBuilders.size) {
+                                    throw InvalidOptionException(
+                                        "link",
+                                        "The given message doesn't have that many embeds."
+                                    )
+                                }
 
-                            embedBuilders[count] = embed
-                            embeds = embedBuilders
+                                embedBuilders[editIndex] = parsedEmbeds.first()
+                                embedBuilders
+                            }
                         }
 
                         val response = ApplicationService.embed
                         response.color = EmbedColor.Positive.color
-                        response.description = "Embed in message ${message.getJumpUrl()} edited!"
+                        response.description = buildEditResponseDescription(
+                            message,
+                            if (replacesWholeMessage) null else count ?: 0,
+                            message.embeds.map { it.toModel() }
+                        )
 
                         embeds = mutableListOf(response)
                     }
                 }
             }
         }
+    }
+
+
+    private fun parseEmbedInput(source: String): List<EmbedBuilder> {
+        return try {
+            EmbedJsonService.parseEmbeds(source)
+        } catch (_: IOException) {
+            throw InvalidEmbedJsonWarning()
+        } catch (_: JsonDataException) {
+            throw InvalidEmbedJsonWarning()
+        } catch (exception: Exception) {
+            throw CommandExecutionException(exception)
+        }
+    }
+
+    private suspend fun buildEditResponseDescription(
+        message: Message,
+        count: Int?,
+        previousEmbeds: List<EmbedModel>
+    ): String {
+        val editedTarget = if (count == null) "all embeds" else "embed #$count"
+        val previousData = if (count == null) {
+            EmbedJsonService.toJson(previousEmbeds)
+        } else {
+            previousEmbeds.getOrNull(count)?.let { EmbedJsonService.toJson(it) }.orEmpty()
+        }
+
+        val previousReference = if (previousData.length <= PREVIOUS_DATA_INLINE_LIMIT) {
+            "Previous data:\n```\n$previousData\n```"
+        } else {
+            val previousDataUrl = ContentConnection.authenticated()
+                .uploadFile(previousData.toByteArray(StandardCharsets.UTF_8))
+                ?.let { ContentConnection.authenticated().getCdnUrl(it).toString() }
+                ?: throw CommandExecutionException("Couldn't upload the previous embed data to the CDN.")
+
+            "Previous data is too large to display inline: $previousDataUrl"
+        }
+
+        return "Edited $editedTarget in message ${message.getJumpUrl()}!\n$previousReference"
     }
 
     open inner class MessageLinkArguments : Arguments() {
@@ -439,5 +367,9 @@ class EmbedCommand : Extension() {
             minValue = 0
             maxValue = 25
         }
+    }
+
+    private companion object {
+        const val PREVIOUS_DATA_INLINE_LIMIT = 1800
     }
 }

--- a/src/main/kotlin/net/dungeonhub/application/commands/EmbedCommand.kt
+++ b/src/main/kotlin/net/dungeonhub/application/commands/EmbedCommand.kt
@@ -216,12 +216,19 @@ class EmbedCommand : Extension() {
                         val count = arguments.count
                         val replacesWholeMessage = count == null && arguments.embed.trimStart().startsWith("[")
 
-                        val message = arguments.getMessage()
+                        if (count != null && parsedEmbeds.size > 1) {
+                            throw InvalidOptionException(
+                                "count",
+                                "A count can only be used when editing with a single embed."
+                            )
+                        }
+
+                        val message = arguments.getMessage() ?: throw InvalidOptionException("link")
 
                         //TODO how to handle interaction responses?
 
 
-                        if (message?.author?.isSelf != true) {
+                        if (message.author?.isSelf != true) {
                             throw InvalidOptionException(
                                 "link",
                                 "How should I edit a message that wasn't sent by myself?"

--- a/src/main/kotlin/net/dungeonhub/application/commands/EmbedCommand.kt
+++ b/src/main/kotlin/net/dungeonhub/application/commands/EmbedCommand.kt
@@ -22,8 +22,8 @@ import dev.kordex.core.i18n.toKey
 import dev.kordex.core.utils.getJumpUrl
 import net.dungeonhub.application.config.ConfigProperty
 import net.dungeonhub.application.connection.loadMessageByLink
-import net.dungeonhub.application.connection.toBuilder
-import net.dungeonhub.application.connection.toModel
+import net.dungeonhub.application.service.toBuilder
+import net.dungeonhub.application.service.toModel
 import net.dungeonhub.application.enums.EmbedColor
 import net.dungeonhub.application.exceptions.CommandExecutionException
 import net.dungeonhub.application.exceptions.InvalidEmbedJsonWarning

--- a/src/main/kotlin/net/dungeonhub/application/commands/LeaderboardCommand.kt
+++ b/src/main/kotlin/net/dungeonhub/application/commands/LeaderboardCommand.kt
@@ -17,7 +17,7 @@ import dev.kordex.core.extensions.publicSlashCommand
 import dev.kordex.core.i18n.toKey
 import dev.kordex.core.pagination.pages.Page
 import dev.kordex.core.utils.getLocale
-import net.dungeonhub.application.connection.copy
+import net.dungeonhub.application.service.copy
 import net.dungeonhub.application.enums.HelpTopic
 import net.dungeonhub.application.loader.LoadExtension
 import net.dungeonhub.application.service.AutoCompletionService

--- a/src/main/kotlin/net/dungeonhub/application/commands/RoleCommand.kt
+++ b/src/main/kotlin/net/dungeonhub/application/commands/RoleCommand.kt
@@ -22,7 +22,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.launch
-import net.dungeonhub.application.connection.copy
+import net.dungeonhub.application.service.copy
 import net.dungeonhub.application.enums.EmbedColor
 import net.dungeonhub.application.exceptions.CommandExecutionException
 import net.dungeonhub.application.exceptions.CommandExecutionWarning

--- a/src/main/kotlin/net/dungeonhub/application/commands/StaticMessageCommand.kt
+++ b/src/main/kotlin/net/dungeonhub/application/commands/StaticMessageCommand.kt
@@ -24,7 +24,7 @@ import dev.kordex.core.extensions.event
 import dev.kordex.core.extensions.publicSlashCommand
 import dev.kordex.core.i18n.toKey
 import dev.kordex.core.pagination.pages.Page
-import net.dungeonhub.application.connection.copy
+import net.dungeonhub.application.service.copy
 import net.dungeonhub.application.enums.EmbedColor
 import net.dungeonhub.application.exceptions.CommandExecutionException
 import net.dungeonhub.application.exceptions.CommandExecutionWarning

--- a/src/main/kotlin/net/dungeonhub/application/commands/WarningSystem.kt
+++ b/src/main/kotlin/net/dungeonhub/application/commands/WarningSystem.kt
@@ -21,7 +21,7 @@ import io.ktor.client.request.*
 import io.ktor.client.statement.*
 import io.ktor.http.*
 import net.dungeonhub.application.connection.DiscordConnection
-import net.dungeonhub.application.connection.copy
+import net.dungeonhub.application.service.copy
 import net.dungeonhub.application.enums.EmbedColor
 import net.dungeonhub.application.enums.ServerProperty
 import net.dungeonhub.application.exceptions.CommandExecutionException

--- a/src/main/kotlin/net/dungeonhub/application/connection/DiscordConnection.kt
+++ b/src/main/kotlin/net/dungeonhub/application/connection/DiscordConnection.kt
@@ -1,14 +1,11 @@
 package net.dungeonhub.application.connection
 
-import com.google.gson.JsonElement
-import com.google.gson.JsonObject
 import dev.kord.common.annotation.KordUnsafe
 import dev.kord.common.entity.PresenceStatus
 import dev.kord.common.entity.Snowflake
 import dev.kord.core.Kord
 import dev.kord.core.behavior.channel.asChannelOfOrNull
 import dev.kord.core.entity.Embed
-import dev.kord.core.entity.Embed.*
 import dev.kord.core.entity.Member
 import dev.kord.core.entity.Message
 import dev.kord.core.entity.User
@@ -43,14 +40,10 @@ import net.dungeonhub.application.loader.ClassLoader
 import net.dungeonhub.application.loader.OnStart
 import net.dungeonhub.application.loader.StartPriority
 import net.dungeonhub.application.loader.StartupListener
-import net.dungeonhub.application.misc.EmbedModel
 import net.dungeonhub.application.service.ApplicationService
 import net.dungeonhub.application.service.color
-import net.dungeonhub.service.MoshiService
-import net.dungeonhub.wrapper.kord.toJavaColor
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
-import java.awt.Color
 import java.time.Instant
 import java.util.*
 import java.util.regex.Pattern
@@ -252,20 +245,6 @@ fun User.getMutualServers(): Flow<Member> {
     }
 }
 
-@OptIn(ExperimentalTime::class)
-fun EmbedBuilder.copy(other: EmbedBuilder) {
-    this.description = other.description
-    this.title = other.title
-    this.footer = other.footer
-    this.fields = other.fields
-    this.color = other.color
-    this.timestamp = other.timestamp
-    this.url = other.url
-    this.image = other.image
-    this.author = other.author
-    this.thumbnail = other.thumbnail
-}
-
 private val messageLinkPattern = Pattern.compile(
     "(?x)                               # enable comment mode \n" +
             "(?i)                             # ignore case \n" +
@@ -287,158 +266,6 @@ suspend fun Kord.loadMessageByLink(messageLink: String): Message? {
     return getChannel(Snowflake(matcher.group("channel")))
         ?.asChannelOfOrNull<MessageChannel>()
         ?.getMessage(Snowflake(matcher.group("message")))
-}
-
-fun EmbedBuilder.setFields(value: JsonElement) {
-    value.asJsonArray.asList().stream()
-        .map { obj: JsonElement -> obj.asJsonObject }
-        .forEach { jsonObject: JsonObject ->
-            field(
-                jsonObject.getAsJsonPrimitive("name").asString,
-                jsonObject.getAsJsonPrimitive("inline")?.asBoolean ?: false
-            ) {
-                jsonObject.getAsJsonPrimitive("value").asString
-            }
-        }
-}
-
-fun EmbedBuilder.setFooter(value: JsonElement) {
-    val footer = value.asJsonObject
-
-    footer {
-        text = footer.getAsJsonPrimitive("text").asString
-        icon = footer.getAsJsonPrimitive("icon")?.asString
-    }
-}
-
-fun EmbedBuilder.setThumbnail(value: JsonElement) {
-    thumbnail {
-        url = value.asJsonObject.getAsJsonPrimitive("url").asString
-    }
-}
-
-fun EmbedBuilder.setAuthor(value: JsonElement) {
-    if (value.isJsonPrimitive) {
-        author {
-            name = value.asString
-        }
-    } else {
-        val jsonObject = value.asJsonObject
-
-        author {
-            name = jsonObject.getAsJsonPrimitive("name").asString
-            url = jsonObject.getAsJsonPrimitive("url")?.asString
-            icon = jsonObject.getAsJsonPrimitive("icon")?.asString
-        }
-    }
-}
-
-@OptIn(ExperimentalTime::class)
-fun EmbedBuilder.applyJson(key: String, value: JsonElement) {
-    when (key) {
-        "title" -> title = value.asString
-        "description" -> description = value.asString
-        "author" -> setAuthor(value)
-        "url" -> url = value.asString
-        "color" -> color = run {
-            val internalColor = MoshiService.moshi.adapter(Color::class.java).fromJsonValue(
-                value.asString
-            )!!
-            dev.kord.common.Color(internalColor.red, internalColor.green, internalColor.blue)
-        }
-
-        "fields" -> setFields(value)
-        "footer" -> setFooter(value)
-        "timestamp" -> timestamp =
-            MoshiService.moshi.adapter(Instant::class.java).fromJson(value.asString)!!.toKotlinInstant()
-
-        "thumbnail" -> setThumbnail(value)
-        "image" -> image = if(value.isJsonNull) null else value.asString
-    }
-}
-
-@OptIn(ExperimentalTime::class)
-fun Embed.toBuilder(): EmbedBuilder {
-    val embed = EmbedBuilder()
-
-    embed.title = title
-    embed.description = description
-    embed.url = url
-    embed.timestamp = timestamp
-    embed.color = color
-    embed.image = image?.url
-    embed.footer = footer?.toBuilder()
-    embed.thumbnail = thumbnail?.toBuilder()
-    embed.author = author?.toBuilder()
-    embed.fields = fields.map { it.toBuilder() }.toMutableList()
-
-    return embed
-}
-
-fun Author.toBuilder(): EmbedBuilder.Author {
-    val author = EmbedBuilder.Author()
-
-    author.name = name
-    author.url = url
-    author.icon = iconUrl
-
-    return author
-}
-
-fun Field.toBuilder(): EmbedBuilder.Field {
-    val field = EmbedBuilder.Field()
-
-    field.name = name
-    field.inline = inline
-    field.value = value
-
-    return field
-}
-
-@OptIn(ExperimentalTime::class)
-fun Embed.toModel(): EmbedModel {
-    val embed = EmbedModel(
-        title,
-        description,
-        url,
-        timestamp?.toJavaInstant(),
-        color?.toJavaColor(),
-        image?.url,
-        footer?.toBuilder(),
-        thumbnail?.toBuilder(),
-        author?.toModel()
-    )
-
-    embed.fields = fields.map { it.toModel() }.toMutableList()
-
-    return embed
-}
-
-fun Footer.toBuilder(): EmbedBuilder.Footer {
-    val footer = EmbedBuilder.Footer()
-
-    footer.text = text
-    footer.icon = iconUrl
-
-    return footer
-}
-
-fun Thumbnail.toBuilder(): EmbedBuilder.Thumbnail? {
-    val url = url ?: return null
-
-    val thumbnail = EmbedBuilder.Thumbnail()
-
-    thumbnail.url = url
-
-    return thumbnail
-}
-
-fun Author.toModel(): EmbedModel.Author {
-    return EmbedModel.Author(name, url, iconUrl)
-}
-
-fun Field.toModel(): EmbedModel.Field {
-    return EmbedModel.Field(name, inline, value)
 }
 
 fun Duration.withNanos(nanos: Int): Duration {

--- a/src/main/kotlin/net/dungeonhub/application/listener/ticket/TicketCreateListener.kt
+++ b/src/main/kotlin/net/dungeonhub/application/listener/ticket/TicketCreateListener.kt
@@ -31,12 +31,12 @@ import net.dungeonhub.application.commands.TicketSystem.Companion.replacePlaceho
 import net.dungeonhub.application.commands.TicketSystem.Companion.scheduler
 import net.dungeonhub.application.commands.TicketSystem.Companion.updateTicketPermissions
 import net.dungeonhub.application.commands.addSilentLinkButtons
-import net.dungeonhub.application.connection.applyJson
 import net.dungeonhub.application.enums.EmbedColor
 import net.dungeonhub.application.exceptions.FailedToLoadEmbedException
 import net.dungeonhub.application.loader.LoadExtension
 import net.dungeonhub.application.misc.TicketPlaceholders
 import net.dungeonhub.application.service.ApplicationService
+import net.dungeonhub.application.service.EmbedJsonService
 import net.dungeonhub.application.service.MessagesService
 import net.dungeonhub.application.service.addEmbed
 import net.dungeonhub.application.service.color
@@ -404,54 +404,14 @@ class TicketCreateListener : Extension() {
             }
         }
 
-        suspend fun parseEmbeds(embedData: JsonElement, placeholders: TicketPlaceholders): MutableList<EmbedBuilder> {
-            val embedBuilders: MutableList<EmbedBuilder> = mutableListOf()
-
-            suspend fun parseJsonObjectEmbed(jsonElement: JsonElement): EmbedBuilder? {
-                val embedBuilder = EmbedBuilder()
-
-                val jsonObject = jsonElement.asJsonObject
-
-                if(jsonObject.has("customEmbed") && !jsonObject.getAsJsonPrimitive("customEmbed")?.asString.isNullOrEmpty()) {
-                    return buildCustomEmbed(
-                        jsonObject.getAsJsonPrimitive("customEmbed")?.asString!!,
-                        placeholders,
-                        jsonObject.getAsJsonPrimitive("customData")?.asString
-                    )
-                }
-
-                jsonObject
-                    .entrySet()
-                    .forEach { entry: Map.Entry<String, JsonElement> ->
-                        embedBuilder.applyJson(
-                            entry.key,
-                            replacePlaceholders(entry.value, placeholders)
-                        )
-                    }
-
-                return embedBuilder
-            }
-
-            try {
-                if (embedData.isJsonObject) {
-                    parseJsonObjectEmbed(embedData)?.let { embedBuilders.add(it) }
-                } else if (embedData.isJsonArray) {
-                    embedData.asJsonArray
-                        .forEach { jsonElement: JsonElement ->
-                            if (jsonElement.isJsonObject) {
-                                parseJsonObjectEmbed(jsonElement)?.let { embedBuilders.add(it) }
-                            } else if (jsonElement.isJsonPrimitive) {
-                                buildCustomEmbed(jsonElement.asString, placeholders)?.let { embedBuilders.add(it) }
-                            }
-                        }
-                } else if (embedData.isJsonPrimitive) {
-                    buildCustomEmbed(embedData.asString, placeholders)?.let { embedBuilders.add(it) }
-                }
-            } catch (_: JsonSyntaxException) {
-
-            }
-
-            return embedBuilders
+        suspend fun parseEmbeds(
+            embedData: JsonElement,
+            placeholders: TicketPlaceholders
+        ): MutableList<EmbedBuilder> {
+            val resolvedEmbedData = replacePlaceholders(embedData, placeholders)
+            return EmbedJsonService.parseEmbeds(resolvedEmbedData.toString()) { type, customData ->
+                buildCustomEmbed(type, placeholders, customData)
+            }.toMutableList()
         }
 
         suspend fun buildCustomEmbed(type: String, placeholders: TicketPlaceholders, customData: String? = null): EmbedBuilder? {

--- a/src/main/kotlin/net/dungeonhub/application/listener/ticket/TicketCreateListener.kt
+++ b/src/main/kotlin/net/dungeonhub/application/listener/ticket/TicketCreateListener.kt
@@ -4,6 +4,7 @@ import com.google.gson.JsonElement
 import com.google.gson.JsonObject
 import com.google.gson.JsonParser
 import com.google.gson.JsonSyntaxException
+import com.squareup.moshi.JsonDataException
 import dev.kord.common.entity.ButtonStyle
 import dev.kord.common.entity.Snowflake
 import dev.kord.common.entity.TextInputStyle
@@ -409,9 +410,14 @@ class TicketCreateListener : Extension() {
             placeholders: TicketPlaceholders
         ): MutableList<EmbedBuilder> {
             val resolvedEmbedData = replacePlaceholders(embedData, placeholders)
-            return EmbedJsonService.parseEmbeds(resolvedEmbedData.toString()) { type, customData ->
-                buildCustomEmbed(type, placeholders, customData)
-            }.toMutableList()
+            return try {
+                EmbedJsonService.parseEmbeds(resolvedEmbedData.toString()) { type, customData ->
+                    buildCustomEmbed(type, placeholders, customData)
+                }.toMutableList()
+            } catch (exception: JsonDataException) {
+                logger.error("Failed to parse ticket message embeds.", exception)
+                mutableListOf()
+            }
         }
 
         suspend fun buildCustomEmbed(type: String, placeholders: TicketPlaceholders, customData: String? = null): EmbedBuilder? {

--- a/src/main/kotlin/net/dungeonhub/application/listener/ticket/TicketCreateListener.kt
+++ b/src/main/kotlin/net/dungeonhub/application/listener/ticket/TicketCreateListener.kt
@@ -61,7 +61,6 @@ import org.slf4j.LoggerFactory
 @LoadExtension
 class TicketCreateListener : Extension() {
     override val name = "ticket-create-listener"
-    private val logger = LoggerFactory.getLogger(javaClass)
 
     override suspend fun setup() {
         event<GuildButtonInteractionCreateEvent> {
@@ -210,6 +209,7 @@ class TicketCreateListener : Extension() {
     }
 
     companion object {
+        private val logger = LoggerFactory.getLogger(TicketCreateListener::class.java)
         const val DEFAULT_CONTENT = "Welcome, {user.mention}!\nPlease describe your {panel.name} request below further."
 
         suspend fun checkTicketOpen(

--- a/src/main/kotlin/net/dungeonhub/application/listener/ticket/TicketTranscriptListener.kt
+++ b/src/main/kotlin/net/dungeonhub/application/listener/ticket/TicketTranscriptListener.kt
@@ -29,7 +29,6 @@ import net.dungeonhub.application.commands.TicketSystem
 import net.dungeonhub.application.commands.TicketSystem.Companion.isAllowedToChangeState
 import net.dungeonhub.application.commands.TicketSystem.Companion.replacePlaceholders
 import net.dungeonhub.application.connection.DiscordConnection
-import net.dungeonhub.application.connection.applyJson
 import net.dungeonhub.application.enums.EmbedColor
 import net.dungeonhub.application.enums.ServerProperty
 import net.dungeonhub.application.event.TicketTranscriptCreatedEvent
@@ -38,6 +37,7 @@ import net.dungeonhub.application.misc.TicketPlaceholders
 import net.dungeonhub.application.service.addEmbed
 import net.dungeonhub.application.service.buildEmbed
 import net.dungeonhub.application.service.color
+import net.dungeonhub.application.service.EmbedJsonService
 import net.dungeonhub.connection.ContentConnection
 import net.dungeonhub.connection.DiscordServerConnection
 import net.dungeonhub.enums.TranscriptTarget
@@ -223,57 +223,19 @@ class TicketTranscriptListener : Extension() {
         }
 
         // TODO maybe merge with the method in the TicketSystem?
-        private suspend fun parseTranscriptDmEmbeds(embedData: JsonElement, placeholders: TicketPlaceholders): MutableList<EmbedBuilder> {
-            val embedBuilders: MutableList<EmbedBuilder> = mutableListOf()
-
-            try {
-                if (embedData.isJsonObject) {
-                    val embedBuilder = EmbedBuilder()
-
-                    embedData.asJsonObject
-                        .entrySet()
-                        .forEach {
-                            embedBuilder.applyJson(
-                                it.key,
-                                replacePlaceholders(it.value, placeholders)
-                            )
-                        }
-
-                    embedBuilders.add(embedBuilder)
-                } else if (embedData.isJsonArray) {
-                    embedData.asJsonArray
-                        .forEach { jsonElement: JsonElement ->
-                            if (jsonElement.isJsonObject) {
-                                val embedBuilder = EmbedBuilder()
-
-                                jsonElement.asJsonObject
-                                    .entrySet()
-                                    .forEach { entry: Map.Entry<String, JsonElement> ->
-                                        embedBuilder.applyJson(
-                                            entry.key,
-                                            replacePlaceholders(entry.value, placeholders)
-                                        )
-                                    }
-
-                                embedBuilders.add(embedBuilder)
-                            } else if (jsonElement.isJsonPrimitive) {
-                                buildCustomEmbed(jsonElement.asString, placeholders)?.let { embedBuilders.add(it) }
-                            }
-                        }
-                } else if (embedData.isJsonPrimitive) {
-                    buildCustomEmbed(embedData.asString, placeholders)?.let { embedBuilders.add(it) }
-                }
-            } catch (_: JsonSyntaxException) {
-
-            }
-
-            return embedBuilders
+        private suspend fun parseTranscriptDmEmbeds(
+            embedData: JsonElement,
+            placeholders: TicketPlaceholders
+        ): MutableList<EmbedBuilder> {
+            val resolvedEmbedData = replacePlaceholders(embedData, placeholders)
+            return EmbedJsonService.parseEmbeds(resolvedEmbedData.toString()) { type, _ ->
+                buildCustomEmbed(type, placeholders)
+            }.toMutableList()
         }
 
         private suspend fun buildCustomEmbed(type: String, placeholders: TicketPlaceholders): EmbedBuilder? {
             return when (type) {
                 "transcript" -> generateTranscriptEmbed(placeholders, false)
-
                 else -> null
             }
         }

--- a/src/main/kotlin/net/dungeonhub/application/listener/ticket/TicketTranscriptListener.kt
+++ b/src/main/kotlin/net/dungeonhub/application/listener/ticket/TicketTranscriptListener.kt
@@ -3,6 +3,7 @@ package net.dungeonhub.application.listener.ticket
 import com.google.gson.JsonArray
 import com.google.gson.JsonElement
 import com.google.gson.JsonSyntaxException
+import com.squareup.moshi.JsonDataException
 import dev.kord.common.entity.Snowflake
 import dev.kord.core.behavior.MemberBehavior
 import dev.kord.core.behavior.channel.asChannelOf
@@ -228,9 +229,14 @@ class TicketTranscriptListener : Extension() {
             placeholders: TicketPlaceholders
         ): MutableList<EmbedBuilder> {
             val resolvedEmbedData = replacePlaceholders(embedData, placeholders)
-            return EmbedJsonService.parseEmbeds(resolvedEmbedData.toString()) { type, _ ->
-                buildCustomEmbed(type, placeholders)
-            }.toMutableList()
+            return try {
+                EmbedJsonService.parseEmbeds(resolvedEmbedData.toString()) { type, _ ->
+                    buildCustomEmbed(type, placeholders)
+                }.toMutableList()
+            } catch (exception: JsonDataException) {
+                logger.error("Failed to parse transcript DM embeds.", exception)
+                mutableListOf()
+            }
         }
 
         private suspend fun buildCustomEmbed(type: String, placeholders: TicketPlaceholders): EmbedBuilder? {

--- a/src/main/kotlin/net/dungeonhub/application/listener/ticket/TicketTranscriptListener.kt
+++ b/src/main/kotlin/net/dungeonhub/application/listener/ticket/TicketTranscriptListener.kt
@@ -235,7 +235,7 @@ class TicketTranscriptListener : Extension() {
                 }.toMutableList()
             } catch (exception: JsonDataException) {
                 logger.error("Failed to parse transcript DM embeds.", exception)
-                mutableListOf()
+                mutableListOf(generateTranscriptEmbed(placeholders, false))
             }
         }
 

--- a/src/main/kotlin/net/dungeonhub/application/service/EmbedJsonService.kt
+++ b/src/main/kotlin/net/dungeonhub/application/service/EmbedJsonService.kt
@@ -1,0 +1,166 @@
+package net.dungeonhub.application.service
+
+import com.squareup.moshi.JsonDataException
+import com.squareup.moshi.Types
+import com.squareup.moshi.adapter
+import dev.kord.rest.builder.message.EmbedBuilder
+import net.dungeonhub.application.misc.EmbedModel
+import net.dungeonhub.service.MoshiService
+import java.awt.Color
+import java.time.Instant
+import kotlin.time.ExperimentalTime
+import kotlin.time.toKotlinInstant
+
+/**
+ * Parses the embed JSON accepted by the embed commands.
+ *
+ * Discord embeds can be provided as a single JSON object or as a JSON array of objects. Some nested
+ * values also support short forms, for example an author can either be a string or an object.
+ */
+@OptIn(ExperimentalStdlibApi::class)
+object EmbedJsonService {
+    private val anyAdapter = MoshiService.moshi.adapter<Any>()
+    private val mapType = Types.newParameterizedType(Map::class.java, String::class.java, Any::class.java)
+    private val mapAdapter = MoshiService.moshi.adapter<Map<String, Any?>>(mapType)
+    private val listType = Types.newParameterizedType(List::class.java, mapType)
+    private val listAdapter = MoshiService.moshi.adapter<List<Map<String, Any?>>>(listType)
+    private val colorAdapter = MoshiService.moshi.adapter(Color::class.java)
+    private val instantAdapter = MoshiService.moshi.adapter(Instant::class.java)
+    private val embedModelAdapter = MoshiService.moshi.adapter<EmbedModel>()
+    private val embedModelListAdapter = MoshiService.moshi.adapter<List<EmbedModel>>()
+
+    fun parseEmbeds(source: String): List<EmbedBuilder> {
+        val value = anyAdapter.fromJson(source) ?: return emptyList()
+
+        return when (value) {
+            is Map<*, *> -> listOf(mapAdapter.fromJson(source)!!.toEmbedBuilder())
+            is List<*> -> listAdapter.fromJson(source).orEmpty().map { it.toEmbedBuilder() }
+            else -> emptyList()
+        }
+    }
+
+    /**
+     * Parses regular embeds as well as application-specific embeds represented by either a string
+     * or an object containing `customEmbed` and optional `customData` properties.
+     */
+    suspend fun parseEmbeds(
+        source: String,
+        customEmbedBuilder: suspend (type: String, customData: String?) -> EmbedBuilder?
+    ): List<EmbedBuilder> {
+        val value = anyAdapter.fromJson(source) ?: return emptyList()
+
+        return when (value) {
+            is Map<*, *> -> listOfNotNull(value.toCustomOrRegularEmbed(customEmbedBuilder))
+            is List<*> -> value.mapNotNull { element ->
+                when (element) {
+                    is Map<*, *> -> element.toCustomOrRegularEmbed(customEmbedBuilder)
+                    is String -> customEmbedBuilder(element, null)
+                    else -> null
+                }
+            }
+            is String -> listOfNotNull(customEmbedBuilder(value, null))
+            else -> emptyList()
+        }
+    }
+
+    fun toJson(model: EmbedModel): String = embedModelAdapter.toJson(model)
+
+    fun toJson(models: List<EmbedModel>): String = embedModelListAdapter.toJson(models)
+
+    fun toJsonMap(model: EmbedModel): Map<String, Any?> {
+        return mapAdapter.fromJson(toJson(model)).orEmpty()
+    }
+
+    fun toJsonValue(value: Any?): String = anyAdapter.toJson(value)
+
+    private fun Map<String, Any?>.toEmbedBuilder(): EmbedBuilder {
+        val embedBuilder = EmbedBuilder()
+        forEach { (key, value) -> embedBuilder.applyJson(key, value) }
+        return embedBuilder
+    }
+
+    private suspend fun Map<*, *>.toCustomOrRegularEmbed(
+        customEmbedBuilder: suspend (type: String, customData: String?) -> EmbedBuilder?
+    ): EmbedBuilder? {
+        if (containsKey("customEmbed")) {
+            val customEmbed = this["customEmbed"] as? String
+                ?: throw JsonDataException("customEmbed must be a string")
+            if (customEmbed.isBlank()) {
+                throw JsonDataException("customEmbed must not be blank")
+            }
+
+            val customData = this["customData"]?.let {
+                it as? String ?: throw JsonDataException("customData must be a string")
+            }
+            return customEmbedBuilder(customEmbed, customData)
+        }
+
+        return asStringMap()?.toEmbedBuilder()
+    }
+
+    @OptIn(ExperimentalTime::class)
+    fun EmbedBuilder.applyJson(key: String, value: Any?) {
+        when (key) {
+            "title" -> title = value.asStringOrNull()
+            "description" -> description = value.asStringOrNull()
+            "author" -> setAuthor(value)
+            "url" -> url = value.asStringOrNull()
+            "color" -> color = value?.let { colorAdapter.fromJsonValue(it) }?.let {
+                dev.kord.common.Color(it.red, it.green, it.blue)
+            }
+            "fields" -> setFields(value)
+            "footer" -> setFooter(value)
+            "timestamp" -> timestamp = value.asStringOrNull()?.let { instantAdapter.fromJson(it)?.toKotlinInstant() }
+            "thumbnail" -> setThumbnail(value)
+            "image" -> image = value.asStringOrNull()
+        }
+    }
+
+    private fun EmbedBuilder.setFields(value: Any?) {
+        val fields = value.asListOrEmpty()
+        fields.mapNotNull { it.asMapOrNull() }.forEach { field ->
+            val name = field["name"].asStringOrNull() ?: return@forEach
+            val fieldValue = field["value"].asStringOrNull() ?: return@forEach
+            field(name, field["inline"] as? Boolean ?: false) { fieldValue }
+        }
+    }
+
+    private fun EmbedBuilder.setFooter(value: Any?) {
+        val footerData = value.asMapOrNull() ?: return
+        footer {
+            text = footerData["text"].asStringOrNull().orEmpty()
+            icon = footerData["icon"].asStringOrNull()
+        }
+    }
+
+    private fun EmbedBuilder.setThumbnail(value: Any?) {
+        val thumbnailUrl = value.asMapOrNull()?.get("url").asStringOrNull() ?: return
+        thumbnail { url = thumbnailUrl }
+    }
+
+    private fun EmbedBuilder.setAuthor(value: Any?) {
+        if (value is String) {
+            author { name = value }
+            return
+        }
+
+        val authorData = value.asMapOrNull() ?: return
+        author {
+            name = authorData["name"].asStringOrNull()
+            url = authorData["url"].asStringOrNull()
+            icon = authorData["icon"].asStringOrNull()
+        }
+    }
+
+    private fun Any?.asStringOrNull(): String? = this as? String
+
+    private fun Any?.asListOrEmpty(): List<*> = this as? List<*> ?: emptyList<Any>()
+
+    @Suppress("UNCHECKED_CAST")
+    private fun Any?.asMapOrNull(): Map<String, Any?>? = this as? Map<String, Any?>
+
+    @Suppress("UNCHECKED_CAST")
+    private fun Map<*, *>.asStringMap(): Map<String, Any?>? {
+        return takeIf { keys.all { key -> key is String } } as? Map<String, Any?>
+    }
+}

--- a/src/main/kotlin/net/dungeonhub/application/service/EmbedJsonService.kt
+++ b/src/main/kotlin/net/dungeonhub/application/service/EmbedJsonService.kt
@@ -101,9 +101,7 @@ object EmbedJsonService {
             "description" -> description = value.asStringOrNull()
             "author" -> setAuthor(value)
             "url" -> url = value.asStringOrNull()
-            "color" -> color = value?.let { colorAdapter.fromJsonValue(it) }?.let {
-                dev.kord.common.Color(it.red, it.green, it.blue)
-            }
+            "color" -> color = value?.let(::parseColor)
             "fields" -> setFields(value)
             "footer" -> setFooter(value)
             "timestamp" -> timestamp = value?.let { instantAdapter.fromJsonValue(it)?.toKotlinInstant() }
@@ -149,6 +147,14 @@ object EmbedJsonService {
     }
 
     private fun Any?.asStringOrNull(): String? = this as? String
+
+    private fun parseColor(value: Any): dev.kord.common.Color? {
+        return try {
+            colorAdapter.fromJsonValue(value)?.let { dev.kord.common.Color(it.red, it.green, it.blue) }
+        } catch (exception: NumberFormatException) {
+            throw JsonDataException("color must be a valid color value", exception)
+        }
+    }
 
     private fun String.requireValidCustomEmbed(): String {
         if (isBlank()) {

--- a/src/main/kotlin/net/dungeonhub/application/service/EmbedJsonService.kt
+++ b/src/main/kotlin/net/dungeonhub/application/service/EmbedJsonService.kt
@@ -54,11 +54,11 @@ object EmbedJsonService {
             is List<*> -> value.mapNotNull { element ->
                 when (element) {
                     is Map<*, *> -> element.toCustomOrRegularEmbed(customEmbedBuilder)
-                    is String -> customEmbedBuilder(element, null)
+                    is String -> customEmbedBuilder(element.requireValidCustomEmbed(), null)
                     else -> null
                 }
             }
-            is String -> listOfNotNull(customEmbedBuilder(value, null))
+            is String -> listOfNotNull(customEmbedBuilder(value.requireValidCustomEmbed(), null))
             else -> emptyList()
         }
     }
@@ -85,14 +85,10 @@ object EmbedJsonService {
         if (containsKey("customEmbed")) {
             val customEmbed = this["customEmbed"] as? String
                 ?: throw JsonDataException("customEmbed must be a string")
-            if (customEmbed.isBlank()) {
-                throw JsonDataException("customEmbed must not be blank")
-            }
-
             val customData = this["customData"]?.let {
                 it as? String ?: throw JsonDataException("customData must be a string")
             }
-            return customEmbedBuilder(customEmbed, customData)
+            return customEmbedBuilder(customEmbed.requireValidCustomEmbed(), customData)
         }
 
         return asStringMap()?.toEmbedBuilder()
@@ -110,7 +106,7 @@ object EmbedJsonService {
             }
             "fields" -> setFields(value)
             "footer" -> setFooter(value)
-            "timestamp" -> timestamp = value.asStringOrNull()?.let { instantAdapter.fromJson(it)?.toKotlinInstant() }
+            "timestamp" -> timestamp = value?.let { instantAdapter.fromJsonValue(it)?.toKotlinInstant() }
             "thumbnail" -> setThumbnail(value)
             "image" -> image = value.asStringOrNull()
         }
@@ -153,6 +149,13 @@ object EmbedJsonService {
     }
 
     private fun Any?.asStringOrNull(): String? = this as? String
+
+    private fun String.requireValidCustomEmbed(): String {
+        if (isBlank()) {
+            throw JsonDataException("customEmbed must not be blank")
+        }
+        return this
+    }
 
     private fun Any?.asListOrEmpty(): List<*> = this as? List<*> ?: emptyList<Any>()
 

--- a/src/main/kotlin/net/dungeonhub/application/service/EmbedJsonService.kt
+++ b/src/main/kotlin/net/dungeonhub/application/service/EmbedJsonService.kt
@@ -3,12 +3,19 @@ package net.dungeonhub.application.service
 import com.squareup.moshi.JsonDataException
 import com.squareup.moshi.Types
 import com.squareup.moshi.adapter
+import dev.kord.core.entity.Embed
+import dev.kord.core.entity.Embed.Author
+import dev.kord.core.entity.Embed.Field
+import dev.kord.core.entity.Embed.Footer
+import dev.kord.core.entity.Embed.Thumbnail
 import dev.kord.rest.builder.message.EmbedBuilder
 import net.dungeonhub.application.misc.EmbedModel
 import net.dungeonhub.service.MoshiService
+import net.dungeonhub.wrapper.kord.toJavaColor
 import java.awt.Color
 import java.time.Instant
 import kotlin.time.ExperimentalTime
+import kotlin.time.toJavaInstant
 import kotlin.time.toKotlinInstant
 
 /**
@@ -173,3 +180,84 @@ object EmbedJsonService {
         return takeIf { keys.all { key -> key is String } } as? Map<String, Any?>
     }
 }
+
+@OptIn(ExperimentalTime::class)
+fun EmbedBuilder.copy(other: EmbedBuilder) {
+    description = other.description
+    title = other.title
+    footer = other.footer
+    fields = other.fields
+    color = other.color
+    timestamp = other.timestamp
+    url = other.url
+    image = other.image
+    author = other.author
+    thumbnail = other.thumbnail
+}
+
+@OptIn(ExperimentalTime::class)
+fun Embed.toBuilder(): EmbedBuilder {
+    val embed = EmbedBuilder()
+    embed.title = title
+    embed.description = description
+    embed.url = url
+    embed.timestamp = timestamp
+    embed.color = color
+    embed.image = image?.url
+    embed.footer = footer?.toBuilder()
+    embed.thumbnail = thumbnail?.toBuilder()
+    embed.author = author?.toBuilder()
+    embed.fields = fields.map { it.toBuilder() }.toMutableList()
+    return embed
+}
+
+fun Author.toBuilder(): EmbedBuilder.Author {
+    val author = EmbedBuilder.Author()
+    author.name = name
+    author.url = url
+    author.icon = iconUrl
+    return author
+}
+
+fun Field.toBuilder(): EmbedBuilder.Field {
+    val field = EmbedBuilder.Field()
+    field.name = name
+    field.inline = inline
+    field.value = value
+    return field
+}
+
+@OptIn(ExperimentalTime::class)
+fun Embed.toModel(): EmbedModel {
+    val embed = EmbedModel(
+        title,
+        description,
+        url,
+        timestamp?.toJavaInstant(),
+        color?.toJavaColor(),
+        image?.url,
+        footer?.toBuilder(),
+        thumbnail?.toBuilder(),
+        author?.toModel()
+    )
+    embed.fields = fields.map { it.toModel() }.toMutableList()
+    return embed
+}
+
+fun Footer.toBuilder(): EmbedBuilder.Footer {
+    val footer = EmbedBuilder.Footer()
+    footer.text = text
+    footer.icon = iconUrl
+    return footer
+}
+
+fun Thumbnail.toBuilder(): EmbedBuilder.Thumbnail? {
+    val thumbnailUrl = url ?: return null
+    val thumbnail = EmbedBuilder.Thumbnail()
+    thumbnail.url = thumbnailUrl
+    return thumbnail
+}
+
+fun Author.toModel(): EmbedModel.Author = EmbedModel.Author(name, url, iconUrl)
+
+fun Field.toModel(): EmbedModel.Field = EmbedModel.Field(name, inline, value)

--- a/src/main/kotlin/net/dungeonhub/application/service/StaticMessageService.kt
+++ b/src/main/kotlin/net/dungeonhub/application/service/StaticMessageService.kt
@@ -1,8 +1,6 @@
 package net.dungeonhub.application.service
 
-import com.google.gson.JsonElement
-import com.google.gson.JsonObject
-import com.google.gson.JsonSyntaxException
+import com.squareup.moshi.JsonDataException
 import dev.kord.common.entity.ButtonStyle
 import dev.kord.common.entity.Snowflake
 import dev.kord.core.behavior.MessageBehavior
@@ -27,7 +25,6 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import net.dungeonhub.application.commands.addLeaderboardButtons
 import net.dungeonhub.application.connection.DiscordConnection
-import net.dungeonhub.application.connection.applyJson
 import net.dungeonhub.application.enums.EmbedColor
 import net.dungeonhub.application.enums.ServerProperty
 import net.dungeonhub.application.exceptions.CommandExecutionException
@@ -47,8 +44,8 @@ import net.dungeonhub.model.carry_type.CarryTypeModel
 import net.dungeonhub.model.reputation.ReputationLeaderboardModel
 import net.dungeonhub.model.reputation.ReputationSumModel
 import net.dungeonhub.model.static_message.StaticMessageModel
-import net.dungeonhub.service.GsonService
 import org.slf4j.LoggerFactory
+import java.io.IOException
 import java.time.Instant
 import java.util.concurrent.ConcurrentLinkedDeque
 import kotlin.time.Duration.Companion.hours
@@ -347,22 +344,15 @@ object StaticMessageService : StartupListener {
             }
 
             StaticMessageType.TicketPanel -> {
-                val embed = EmbedBuilder()
-
-                @Suppress("DEPRECATION")
-                val embedOverride = try {
-                    staticMessage.embedOverride?.let {
-                        GsonService.gson.fromJson(it, JsonObject::class.java)
-                    }
-                } catch (_: JsonSyntaxException) {
-                    null
-                }
-
-                embedOverride?.entrySet()?.forEach { entry: Map.Entry<String, JsonElement> ->
-                    embed.applyJson(
-                        entry.key,
-                        entry.value
-                    )
+                val embed = try {
+                    staticMessage.embedOverride
+                        ?.takeIf { it.trimStart().startsWith("{") }
+                        ?.let { EmbedJsonService.parseEmbeds(it).singleOrNull() }
+                        ?: EmbedBuilder()
+                } catch (_: IOException) {
+                    EmbedBuilder()
+                } catch (_: JsonDataException) {
+                    EmbedBuilder()
                 }
 
                 if(staticMessage.objectIds.isEmpty()) {

--- a/src/test/kotlin/net/dungeonhub/application/service/EmbedJsonServiceTest.kt
+++ b/src/test/kotlin/net/dungeonhub/application/service/EmbedJsonServiceTest.kt
@@ -109,6 +109,46 @@ class EmbedJsonServiceTest {
     }
 
     @Test
+    fun `rejects trailing data after valid json`() {
+        assertFailsWith<IOException> {
+            EmbedJsonService.parseEmbeds("""{"title":"Valid"} trailing""")
+        }
+    }
+
+    @Test
+    fun `rejects non-object values in regular embed arrays`() {
+        assertFailsWith<JsonDataException> {
+            EmbedJsonService.parseEmbeds("""[{"title":"Valid"},42]""")
+        }
+    }
+
+    @Test
+    fun `rejects invalid color values`() {
+        val exception = assertFailsWith<JsonDataException> {
+            EmbedJsonService.parseEmbeds("""{"color":"definitely-not-a-color"}""")
+        }
+
+        assertEquals("color must be a valid color value", exception.message)
+    }
+
+    @Test
+    fun `rejects invalid timestamp values`() {
+        assertFailsWith<JsonDataException> {
+            EmbedJsonService.parseEmbeds("""{"timestamp":"yesterday"}""")
+        }
+    }
+
+    @Test
+    fun `accepts whitespace and escaped unicode input`() {
+        val embed = EmbedJsonService.parseEmbeds(
+            "  \n\t{\"title\":\"Dungeon \\u2764 Hub\",\"description\":null}\r\n  "
+        ).single()
+
+        assertEquals("Dungeon ❤ Hub", embed.title)
+        assertNull(embed.description)
+    }
+
+    @Test
     fun `serializes single embed model`() {
         val timestamp = Instant.ofEpochMilli(1710000000000)
         val color = Color(12, 34, 56)

--- a/src/test/kotlin/net/dungeonhub/application/service/EmbedJsonServiceTest.kt
+++ b/src/test/kotlin/net/dungeonhub/application/service/EmbedJsonServiceTest.kt
@@ -1,0 +1,247 @@
+package net.dungeonhub.application.service
+
+import com.squareup.moshi.JsonDataException
+import dev.kord.rest.builder.message.EmbedBuilder
+import kotlinx.coroutines.runBlocking
+import net.dungeonhub.application.misc.EmbedModel
+import java.io.IOException
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class EmbedJsonServiceTest {
+    @Test
+    fun `deserializes single embed object`() {
+        val embeds = EmbedJsonService.parseEmbeds(
+            """
+            {
+              "title": "Object title",
+              "description": "Object description",
+              "author": "Author name",
+              "fields": [
+                {"name": "Field name", "value": "Field value", "inline": true}
+              ]
+            }
+            """.trimIndent()
+        )
+
+        assertEquals(1, embeds.size)
+        assertEquals("Object title", embeds[0].title)
+        assertEquals("Object description", embeds[0].description)
+        assertEquals("Author name", embeds[0].author?.name)
+        assertEquals("Field name", embeds[0].fields.single().name)
+        assertEquals("Field value", embeds[0].fields.single().value)
+        assertEquals(true, embeds[0].fields.single().inline)
+    }
+
+    @Test
+    fun `deserializes embed array`() {
+        val embeds = EmbedJsonService.parseEmbeds(
+            """
+            [
+              {"title": "First", "description": "One"},
+              {"title": "Second", "description": "Two"}
+            ]
+            """.trimIndent()
+        )
+
+        assertEquals(2, embeds.size)
+        assertEquals("First", embeds[0].title)
+        assertEquals("Two", embeds[1].description)
+    }
+
+    @Test
+    fun `deserializes nested object variants`() {
+        val embed = EmbedJsonService.parseEmbeds(
+            """
+            {
+              "author": {"name": "Author", "url": "https://example.com/author", "icon": "https://example.com/author.png"},
+              "footer": {"text": "Footer", "icon": "https://example.com/footer.png"},
+              "thumbnail": {"url": "https://example.com/thumbnail.png"},
+              "image": "https://example.com/image.png",
+              "fields": [{"name": "Default field", "value": "Not inline"}]
+            }
+            """.trimIndent()
+        ).single()
+
+        assertEquals("Author", embed.author?.name)
+        assertEquals("https://example.com/author", embed.author?.url)
+        assertEquals("https://example.com/author.png", embed.author?.icon)
+        assertEquals("Footer", embed.footer?.text)
+        assertEquals("https://example.com/footer.png", embed.footer?.icon)
+        assertEquals("https://example.com/thumbnail.png", embed.thumbnail?.url)
+        assertEquals("https://example.com/image.png", embed.image)
+        assertEquals(false, embed.fields.single().inline)
+    }
+
+    @Test
+    fun `ignores unknown properties`() {
+        val embed = EmbedJsonService.parseEmbeds(
+            """{"title":"Known","unknown":{"nested":true}}"""
+        ).single()
+
+        assertEquals("Known", embed.title)
+    }
+
+    @Test
+    fun `returns empty list for empty array and scalar input`() {
+        assertTrue(EmbedJsonService.parseEmbeds("[]").isEmpty())
+        assertTrue(EmbedJsonService.parseEmbeds("\"not an embed\"").isEmpty())
+        assertTrue(EmbedJsonService.parseEmbeds("null").isEmpty())
+    }
+
+    @Test
+    fun `rejects malformed json`() {
+        assertFailsWith<IOException> {
+            EmbedJsonService.parseEmbeds("{\"title\":")
+        }
+    }
+
+    @Test
+    fun `serializes single embed model`() {
+        val model = EmbedModel(
+            "Serialized title",
+            "Serialized description",
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            EmbedModel.Author("Author", null, null)
+        )
+        model.fields.add(EmbedModel.Field("Field", false, "Value"))
+
+        val json = EmbedJsonService.toJson(model)
+        val parsed = EmbedJsonService.parseEmbeds(json).single()
+
+        assertEquals("Serialized title", parsed.title)
+        assertEquals("Serialized description", parsed.description)
+        assertEquals("Author", parsed.author?.name)
+        assertEquals("Field", parsed.fields.single().name)
+        assertEquals(false, parsed.fields.single().inline)
+        assertEquals("Value", parsed.fields.single().value)
+    }
+
+    @Test
+    fun `serializes embed model array`() {
+        val json = EmbedJsonService.toJson(
+            listOf(
+                EmbedModel("First", null, null, null, null, null, null, null, null),
+                EmbedModel("Second", null, null, null, null, null, null, null, null)
+            )
+        )
+
+        val parsed = EmbedJsonService.parseEmbeds(json)
+
+        assertEquals(2, parsed.size)
+        assertEquals("First", parsed[0].title)
+        assertEquals("Second", parsed[1].title)
+        assertNull(parsed[0].description)
+    }
+
+    @Test
+    fun `converts model to json map`() {
+        val jsonMap = EmbedJsonService.toJsonMap(
+            EmbedModel("Mapped", "Description", null, null, null, null, null, null, null)
+        )
+
+        assertEquals("Mapped", jsonMap["title"])
+        assertEquals("Description", jsonMap["description"])
+    }
+
+    @Test
+    fun `serializes arbitrary json values`() {
+        val json = EmbedJsonService.toJsonValue(
+            mapOf("items" to listOf("first", "second"), "enabled" to true)
+        )
+
+        assertEquals("{\"items\":[\"first\",\"second\"],\"enabled\":true}", json)
+    }
+
+    @Test
+    fun `parses raw string as custom embed`() = runBlocking {
+        val embeds = EmbedJsonService.parseEmbeds("\"stats-overview\"") { type, customData ->
+            EmbedBuilder().apply { title = "$type:$customData" }
+        }
+
+        assertEquals("stats-overview:null", embeds.single().title)
+    }
+
+    @Test
+    fun `parses custom embed object with custom data`() = runBlocking {
+        val embeds = EmbedJsonService.parseEmbeds(
+            """{"customEmbed":"stats-overview","customData":"SKILL_AVERAGE,CATACOMBS"}"""
+        ) { type, customData ->
+            EmbedBuilder().apply {
+                title = type
+                description = customData
+            }
+        }
+
+        assertEquals("stats-overview", embeds.single().title)
+        assertEquals("SKILL_AVERAGE,CATACOMBS", embeds.single().description)
+    }
+
+    @Test
+    fun `parses mixed regular and custom embed array`() = runBlocking {
+        val embeds = EmbedJsonService.parseEmbeds(
+            """[{"title":"Regular"},"price-overview",{"customEmbed":"carry-price","customData":"5"}]"""
+        ) { type, customData ->
+            EmbedBuilder().apply { title = listOfNotNull(type, customData).joinToString(":") }
+        }
+
+        assertEquals(listOf("Regular", "price-overview", "carry-price:5"), embeds.map { it.title })
+    }
+
+    @Test
+    fun `omits unresolved custom embeds`() = runBlocking {
+        val embeds = EmbedJsonService.parseEmbeds(
+            """["unknown",{"title":"Regular"},{"customEmbed":"also-unknown"}]"""
+        ) { _, _ -> null }
+
+        assertEquals(1, embeds.size)
+        assertEquals("Regular", embeds.single().title)
+    }
+
+    @Test
+    fun `rejects non-string custom embed type`() = runBlocking {
+        val exception = assertFailsWith<JsonDataException> {
+            EmbedJsonService.parseEmbeds("""{"customEmbed":42}""") { _, _ -> EmbedBuilder() }
+        }
+
+        assertEquals("customEmbed must be a string", exception.message)
+    }
+
+    @Test
+    fun `rejects blank custom embed type`() = runBlocking {
+        val exception = assertFailsWith<JsonDataException> {
+            EmbedJsonService.parseEmbeds("""{"customEmbed":"  "}""") { _, _ -> EmbedBuilder() }
+        }
+
+        assertEquals("customEmbed must not be blank", exception.message)
+    }
+
+    @Test
+    fun `rejects non-string custom data`() = runBlocking {
+        val exception = assertFailsWith<JsonDataException> {
+            EmbedJsonService.parseEmbeds(
+                """{"customEmbed":"stats-overview","customData":["SKILL_AVERAGE"]}"""
+            ) { _, _ -> EmbedBuilder() }
+        }
+
+        assertEquals("customData must be a string", exception.message)
+    }
+
+    @Test
+    fun `ignores unsupported values in custom embed arrays`() = runBlocking {
+        val embeds = EmbedJsonService.parseEmbeds(
+            """[false,42,null,{"title":"Valid"}]"""
+        ) { _, _ -> EmbedBuilder() }
+
+        assertEquals(1, embeds.size)
+        assertEquals("Valid", embeds.single().title)
+    }
+}

--- a/src/test/kotlin/net/dungeonhub/application/service/EmbedJsonServiceTest.kt
+++ b/src/test/kotlin/net/dungeonhub/application/service/EmbedJsonServiceTest.kt
@@ -1,12 +1,17 @@
 package net.dungeonhub.application.service
 
 import com.squareup.moshi.JsonDataException
+import dev.kord.common.entity.optional.Optional
+import dev.kord.core.Kord
+import dev.kord.core.cache.data.EmbedData
+import dev.kord.core.entity.Embed
 import dev.kord.rest.builder.message.EmbedBuilder
 import kotlinx.coroutines.runBlocking
 import net.dungeonhub.application.misc.EmbedModel
 import java.awt.Color
 import java.io.IOException
 import java.time.Instant
+import sun.misc.Unsafe
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -33,6 +38,59 @@ class EmbedJsonServiceTest {
         assertEquals("Copied field", target.fields.single().name)
         assertEquals("Copied value", target.fields.single().value)
         assertEquals(true, target.fields.single().inline)
+    }
+
+    @Test
+    fun `copy clears values that are absent from source`() {
+        val source = EmbedBuilder()
+        val target = EmbedBuilder().apply {
+            title = "Old title"
+            description = "Old description"
+            field("Old field") { "Old value" }
+        }
+
+        target.copy(source)
+
+        assertNull(target.title)
+        assertNull(target.description)
+        assertTrue(target.fields.isEmpty())
+    }
+
+    @Test
+    fun `converts populated discord embed to builder and model`() {
+        val embed = Embed(
+            EmbedData(
+                title = Optional("Entity title"),
+                description = Optional("Entity description"),
+                url = Optional("https://example.com")
+            ),
+            kordFixture()
+        )
+
+        val builder = embed.toBuilder()
+        val model = embed.toModel()
+
+        assertEquals("Entity title", builder.title)
+        assertEquals("Entity description", builder.description)
+        assertEquals("https://example.com", builder.url)
+        assertEquals("Entity title", model.title)
+        assertEquals("Entity description", model.description)
+        assertEquals("https://example.com", model.url)
+    }
+
+    @Test
+    fun `converts empty discord embed without inventing values`() {
+        val embed = Embed(EmbedData(), kordFixture())
+
+        val builder = embed.toBuilder()
+        val model = embed.toModel()
+
+        assertNull(builder.title)
+        assertNull(builder.description)
+        assertTrue(builder.fields.isEmpty())
+        assertNull(model.title)
+        assertNull(model.description)
+        assertTrue(model.fields.isEmpty())
     }
 
     @Test
@@ -332,5 +390,12 @@ class EmbedJsonServiceTest {
 
         assertEquals(1, embeds.size)
         assertEquals("Valid", embeds.single().title)
+    }
+
+    private fun kordFixture(): Kord {
+        val unsafeField = Unsafe::class.java.getDeclaredField("theUnsafe")
+        unsafeField.isAccessible = true
+        val unsafe = unsafeField.get(null) as Unsafe
+        return unsafe.allocateInstance(Kord::class.java) as Kord
     }
 }

--- a/src/test/kotlin/net/dungeonhub/application/service/EmbedJsonServiceTest.kt
+++ b/src/test/kotlin/net/dungeonhub/application/service/EmbedJsonServiceTest.kt
@@ -4,13 +4,18 @@ import com.squareup.moshi.JsonDataException
 import dev.kord.rest.builder.message.EmbedBuilder
 import kotlinx.coroutines.runBlocking
 import net.dungeonhub.application.misc.EmbedModel
+import java.awt.Color
 import java.io.IOException
+import java.time.Instant
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
+import kotlin.time.ExperimentalTime
+import kotlin.time.toKotlinInstant
 
+@OptIn(ExperimentalTime::class)
 class EmbedJsonServiceTest {
     @Test
     fun `deserializes single embed object`() {
@@ -61,6 +66,8 @@ class EmbedJsonServiceTest {
               "footer": {"text": "Footer", "icon": "https://example.com/footer.png"},
               "thumbnail": {"url": "https://example.com/thumbnail.png"},
               "image": "https://example.com/image.png",
+              "color": "#0C2238",
+              "timestamp": 1710000000000,
               "fields": [{"name": "Default field", "value": "Not inline"}]
             }
             """.trimIndent()
@@ -73,6 +80,8 @@ class EmbedJsonServiceTest {
         assertEquals("https://example.com/footer.png", embed.footer?.icon)
         assertEquals("https://example.com/thumbnail.png", embed.thumbnail?.url)
         assertEquals("https://example.com/image.png", embed.image)
+        assertEquals(dev.kord.common.Color(12, 34, 56), embed.color)
+        assertEquals(Instant.ofEpochMilli(1710000000000).toKotlinInstant(), embed.timestamp)
         assertEquals(false, embed.fields.single().inline)
     }
 
@@ -101,12 +110,14 @@ class EmbedJsonServiceTest {
 
     @Test
     fun `serializes single embed model`() {
+        val timestamp = Instant.ofEpochMilli(1710000000000)
+        val color = Color(12, 34, 56)
         val model = EmbedModel(
             "Serialized title",
             "Serialized description",
             null,
-            null,
-            null,
+            timestamp,
+            color,
             null,
             null,
             null,
@@ -119,6 +130,8 @@ class EmbedJsonServiceTest {
 
         assertEquals("Serialized title", parsed.title)
         assertEquals("Serialized description", parsed.description)
+        assertEquals(timestamp.toKotlinInstant(), parsed.timestamp)
+        assertEquals(dev.kord.common.Color(12, 34, 56), parsed.color)
         assertEquals("Author", parsed.author?.name)
         assertEquals("Field", parsed.fields.single().name)
         assertEquals(false, parsed.fields.single().inline)
@@ -219,6 +232,24 @@ class EmbedJsonServiceTest {
     fun `rejects blank custom embed type`() = runBlocking {
         val exception = assertFailsWith<JsonDataException> {
             EmbedJsonService.parseEmbeds("""{"customEmbed":"  "}""") { _, _ -> EmbedBuilder() }
+        }
+
+        assertEquals("customEmbed must not be blank", exception.message)
+    }
+
+    @Test
+    fun `rejects blank raw custom embed type`() = runBlocking {
+        val exception = assertFailsWith<JsonDataException> {
+            EmbedJsonService.parseEmbeds("\"  \"") { _, _ -> EmbedBuilder() }
+        }
+
+        assertEquals("customEmbed must not be blank", exception.message)
+    }
+
+    @Test
+    fun `rejects blank custom embed type in array`() = runBlocking {
+        val exception = assertFailsWith<JsonDataException> {
+            EmbedJsonService.parseEmbeds("[\"valid\",\"\"]") { _, _ -> EmbedBuilder() }
         }
 
         assertEquals("customEmbed must not be blank", exception.message)

--- a/src/test/kotlin/net/dungeonhub/application/service/EmbedJsonServiceTest.kt
+++ b/src/test/kotlin/net/dungeonhub/application/service/EmbedJsonServiceTest.kt
@@ -18,6 +18,24 @@ import kotlin.time.toKotlinInstant
 @OptIn(ExperimentalTime::class)
 class EmbedJsonServiceTest {
     @Test
+    fun `copies embed builder data`() {
+        val source = EmbedBuilder().apply {
+            title = "Copied title"
+            description = "Copied description"
+            field("Copied field", true) { "Copied value" }
+        }
+        val target = EmbedBuilder()
+
+        target.copy(source)
+
+        assertEquals("Copied title", target.title)
+        assertEquals("Copied description", target.description)
+        assertEquals("Copied field", target.fields.single().name)
+        assertEquals("Copied value", target.fields.single().value)
+        assertEquals(true, target.fields.single().inline)
+    }
+
+    @Test
     fun `deserializes single embed object`() {
         val embeds = EmbedJsonService.parseEmbeds(
             """


### PR DESCRIPTION
### Motivation
- Centralize and standardize parsing/serialization of embed JSON across the application to remove duplicated ad-hoc Gson/Moshi parsing logic and to support application-specific custom embed types. 
- Improve error handling and enable serializing embed models back to JSON or CDN-safe values for use in commands and ticket listeners.

### Description
- Add `EmbedJsonService` which parses embed JSON (single object, arrays, or custom types), provides `toJson`, `toJsonMap`, and `toJsonValue` helpers, and includes an `applyJson` integration for building `EmbedBuilder` instances. 
- Refactor `EmbedCommand` to use `EmbedJsonService` (replace inline Gson/Moshi parsing), add `parseEmbedInput` helper and `buildEditResponseDescription` to improve edit responses and support replacing whole-message embeds. 
- Update `TicketCreateListener` and `TicketTranscriptListener` to use `EmbedJsonService.parseEmbeds` with support for resolving custom embed types via callbacks. 
- Remove several direct Gson/Moshi usages and rework imports accordingly. 
- Add comprehensive unit tests for `EmbedJsonService` in `EmbedJsonServiceTest.kt` covering parsing, serialization, error cases and custom embed resolution.

### Testing
- Ran unit tests with `./gradlew test`, including `EmbedJsonServiceTest`, and all tests completed successfully. 
- The new `EmbedJsonService` tests exercised parsing/serialization, custom embed handling, and error conditions and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6cb565e76083229c6d3c880d26ce84)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added consistent JSON embed parsing for single embeds, arrays, and custom formats.
  - Supports converting embeds to JSON, including titles, descriptions, authors, colors, fields, footers, images, and timestamps.
  - Embed editing can replace all embeds or update a selected embed while reporting previous embed data.
  - Added support for JSON-based ticket panel embed overrides.

- **Bug Fixes**
  - Improved validation and handling of malformed, unsupported, or unresolved embed data.
  - Standardized embed behavior across commands, ticket creation, and transcript delivery.

- **Tests**
  - Added coverage for parsing, serialization, custom embeds, nested fields, and validation errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->